### PR TITLE
chore: revert "add support for efcore instrumentation"

### DIFF
--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.10.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageReference Include="Scrutor" Version="5.0.2" />
   </ItemGroup>

--- a/src/ObservabilityExtensions.cs
+++ b/src/ObservabilityExtensions.cs
@@ -40,7 +40,6 @@ public static partial class ObservabilityExtensions
             .WithTracing(t =>
             {
                 t.AddAspNetCoreInstrumentation();
-                t.AddEntityFrameworkCoreInstrumentation();
                 t.AddHttpClientInstrumentation();
                 t.AddAWSInstrumentation();
                 t.AddNpgsql();


### PR DESCRIPTION
Reverts gainsway/lib-dotnet-observability#12