### PR TITLE
chore: introduce default tracing filter on `/healthz` and `/metrics` endpoints

### DIFF
--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -16,7 +16,7 @@
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -24,14 +24,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.10.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore"
-      Version="1.10.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageReference Include="Scrutor" Version="5.0.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="Scrutor" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/ObservabilityExtensions.cs
+++ b/src/ObservabilityExtensions.cs
@@ -43,7 +43,6 @@ public static partial class ObservabilityExtensions
             .WithTracing(t =>
             {
                 t.AddAspNetCoreInstrumentation();
-                t.AddEntityFrameworkCoreInstrumentation();
                 t.AddHttpClientInstrumentation();
                 t.AddAWSInstrumentation();
                 t.AddNpgsql();

--- a/src/ObservabilityExtensions.cs
+++ b/src/ObservabilityExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Npgsql;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
-using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -16,7 +15,9 @@ public static partial class ObservabilityExtensions
     public static void AddObservability(
         this WebApplicationBuilder builder,
         string serviceName,
-        string commitShortSha
+        string commitShortSha,
+        Action<OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions>? aspNetCoreInstrumentationOptions =
+            null
     )
     {
         builder.Services.AddOptions<OtlpExporterOptions>();
@@ -33,16 +34,27 @@ public static partial class ObservabilityExtensions
                 );
                 r.AddEnvironmentVariableDetector();
             })
-            .WithLogging(opt =>
-            {
-            })
+            .WithLogging(opt => { })
             .WithMetrics(m =>
             {
                 m.AddAspNetCoreInstrumentation();
             })
             .WithTracing(t =>
             {
-                t.AddAspNetCoreInstrumentation();
+                t.AddAspNetCoreInstrumentation(
+                    aspNetCoreInstrumentationOptions
+                        ?? (
+                            opt =>
+                            {
+                                opt.Filter = (httpContext) =>
+                                {
+                                    var path = httpContext.Request.Path.ToString();
+                                    return !path.StartsWith("/healthz")
+                                        && !path.StartsWith("/metrics");
+                                };
+                            }
+                        )
+                );
                 t.AddHttpClientInstrumentation();
                 t.AddAWSInstrumentation();
                 t.AddNpgsql();

--- a/test/Observability.Tests.csproj
+++ b/test/Observability.Tests.csproj
@@ -1,40 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Gainsway.Observability.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CSharpier.MSBuild" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
-
-
   <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\src\Observability.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->
This PR closes GAINS-937

## Description

In order to avoid traces pollution with health and metrics endpoints calls, this PR introduce a new default filtering on these endpoints. It is still possible to achieve custom filtering and enhance data by passing the AspNetCoreInstrumentationOptions

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] New tests have been added to cover changes.
