### PR TITLE
chore(deps): update nuget + dotnet tools

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -1,11 +1,5 @@
 {
   "version": 1,
   "isRoot": true,
-  "tools": {
-    "csharpier": {
-      "version": "1.0.0",
-      "commands": ["csharpier"],
-      "rollForward": false
-    }
-  }
+  "tools": {}
 }

--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -20,16 +20,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CSharpier.MSBuild" Version="1.0.0">
+    <PackageReference Include="CSharpier.MSBuild" Version="1.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/test/TraceDecoratorTest.cs
+++ b/test/TraceDecoratorTest.cs
@@ -45,7 +45,7 @@ namespace Gainsway.Observability.Tests
         }
 
         [Test]
-        public async Task DoWorkAsync_ShouldInvokeWithoutException()
+        public void DoWorkAsync_ShouldInvokeWithoutException()
         {
             Assert.DoesNotThrowAsync(async () => await _service.DoWorkAsync());
         }


### PR DESCRIPTION
## Description

On a mission to get rid of warnings about AWSSDK 3.7 vs 4.0 when building project, I've updated all the services, but the issue still persisted. 

Trouble may be with Opentelemetry packages (OpenTelemetry.Instrumentation.AWS), which themselves relied on AWSSDK 3.7. This was changed in 1.12 version: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2720


[Why is dependabot missing in action all over the place?]

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] New tests have been added to cover changes.
