### PR TITLE
feat: add support for grafana RUM-APM integration

### DIFF
--- a/src/GrafanaMiddleware.cs
+++ b/src/GrafanaMiddleware.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Trace;
+
+namespace Gainsway.Observability;
+
+public class GrafanaMiddleware(RequestDelegate next)
+{
+    private readonly RequestDelegate _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var currentSpan = Tracer.CurrentSpan;
+
+        context.Response.Headers.Append(
+            "server-timing",
+            $"traceparent;desc=\"00-{currentSpan.Context.TraceId}-{currentSpan.Context.SpanId}-01\""
+        );
+        await _next(context);
+    }
+}

--- a/src/GrafanaMiddlewareExtensions.cs
+++ b/src/GrafanaMiddlewareExtensions.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Gainsway.Observability;
+
+public static class GrafanaMiddlewareExtensions
+{
+    public static IApplicationBuilder UseGrafanaMiddleware(this IApplicationBuilder app) =>
+        app.UseMiddleware<GrafanaMiddleware>();
+}

--- a/src/GrafanaMiddlewareExtensions.cs
+++ b/src/GrafanaMiddlewareExtensions.cs
@@ -4,6 +4,13 @@ namespace Gainsway.Observability;
 
 public static class GrafanaMiddlewareExtensions
 {
+    /// <summary>
+    /// This middleware adds a "server-timing" header to the response,
+    /// which is useful for monitoring and tracing in Grafana.
+    /// It's manadatory to integrate frontend and backend tracing in Grafana.
+    /// </summary>
+    /// <param name="app"></param>
+    /// <returns></returns>
     public static IApplicationBuilder UseGrafanaMiddleware(this IApplicationBuilder app) =>
         app.UseMiddleware<GrafanaMiddleware>();
 }


### PR DESCRIPTION
https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/apm-integration/

<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->
This PR closes GAINS-1109

## Description

This pull request introduces a new middleware to enhance observability by integrating Grafana server-timing headers into HTTP responses. The changes include the implementation of the middleware and its corresponding extension method for easy integration into the application pipeline.

### Middleware Implementation:

* [`src/GrafanaMiddleware.cs`](diffhunk://#diff-d2858615fe96bda25efc57a99c6d07a4482347db6a0d81a21ff1140e93dc1633R1-R20): Added a new `GrafanaMiddleware` class that appends `server-timing` headers to HTTP responses using OpenTelemetry trace data. This middleware retrieves the current span's trace and span IDs to format the header appropriately.

### Middleware Integration:

* [`src/GrafanaMiddlewareExtensions.cs`](diffhunk://#diff-da513c59a71bccd5e026d19871b93055264e86254a48a5e597cd1c7fc9ac5c69R1-R9): Added an extension method `UseGrafanaMiddleware` to simplify the process of adding the `GrafanaMiddleware` to the application's request pipeline.

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
