### PR TITLE
chore: ignore /ready endpoints from tracing

### DIFF
--- a/src/ObservabilityExtensions.cs
+++ b/src/ObservabilityExtensions.cs
@@ -50,6 +50,7 @@ public static partial class ObservabilityExtensions
                                 {
                                     var path = httpContext.Request.Path.ToString();
                                     return !path.StartsWith("/healthz")
+                                        && !path.StartsWith("/ready")
                                         && !path.StartsWith("/metrics");
                                 };
                             }


### PR DESCRIPTION
## Description


This pull request modifies the `AddObservability` method in `src/ObservabilityExtensions.cs` to refine the filtering logic for HTTP requests. The change ensures that requests starting with `/ready` are excluded alongside `/healthz` and `/metrics`.

* [`src/ObservabilityExtensions.cs`](diffhunk://#diff-cfcf819dd06a950abf51030658615823cfa05b5142ea38ed3350ea1c4e1d5519R53): Updated the filtering logic in `AddObservability` to exclude requests starting with `/ready` in addition to `/healthz` and `/metrics`.

