### PR TITLE
chore: add tracing for temporal activities

### DIFF
--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -31,5 +31,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="Scrutor" Version="6.1.0" />
+    <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/src/ObservabilityExtensions.cs
+++ b/src/ObservabilityExtensions.cs
@@ -7,6 +7,7 @@ using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Temporalio.Extensions.OpenTelemetry;
 
 namespace Gainsway.Observability;
 
@@ -58,6 +59,11 @@ public static partial class ObservabilityExtensions
                 );
                 t.AddHttpClientInstrumentation();
                 t.AddAWSInstrumentation();
+                t.AddSource(
+                    TracingInterceptor.ClientSource.Name,
+                    TracingInterceptor.WorkflowsSource.Name,
+                    TracingInterceptor.ActivitiesSource.Name
+                );
                 t.AddNpgsql();
             })
             .UseOtlpExporter();


### PR DESCRIPTION
<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->
This PR closes GAINS-1311

## Description

This pull request introduces integration with Temporal's OpenTelemetry extension to enhance distributed tracing capabilities within the observability infrastructure. The primary changes involve adding the necessary package, updating imports, and registering new trace sources for Temporal workflows and activities.

**Temporal OpenTelemetry integration:**

* Added the `Temporalio.Extensions.OpenTelemetry` NuGet package to `src/Observability.csproj` to enable tracing for Temporal workflows and activities.
* Imported the `Temporalio.Extensions.OpenTelemetry` namespace in `src/ObservabilityExtensions.cs` to access tracing extension methods.
* Registered Temporal-specific trace sources (`TracingInterceptor.ClientSource.Name`, `TracingInterceptor.WorkflowsSource.Name`, `TracingInterceptor.ActivitiesSource.Name`) in the OpenTelemetry trace configuration to ensure Temporal operations are included in distributed tracing.

