### PR TITLE
chore: dotnet 10 migration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Continuous Integration
     uses: gainsway/github-workflows-public/.github/workflows/nuget.ci.yml@main
     with:
-      dotnet-version: 9.0.x
+      dotnet-version: 10.0.x
     secrets: inherit
 
   publish:
@@ -16,6 +16,5 @@ jobs:
     needs: ci
     uses: gainsway/github-workflows-public/.github/workflows/nuget.publish.yml@main
     with:
-        dotnet-version: 9.0.x
+      dotnet-version: 10.0.x
     secrets: inherit
-    

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -3,13 +3,13 @@ name: Release stable version
 on:
   push:
     tags:
-        - 'v*'
+      - "v*"
 jobs:
   ci:
     name: Continuous Integration
     uses: gainsway/github-workflows-public/.github/workflows/nuget.ci.yml@main
     with:
-      dotnet-version: 9.0.x
+      dotnet-version: 10.0.x
     secrets: inherit
 
   publish:
@@ -17,7 +17,7 @@ jobs:
     needs: ci
     uses: gainsway/github-workflows-public/.github/workflows/nuget.publish.yml@main
     with:
-        dotnet-version: 9.0.x
+      dotnet-version: 10.x
     secrets: inherit
 
   publish-nuget-org:
@@ -25,7 +25,5 @@ jobs:
     needs: ci
     uses: gainsway/github-workflows-public/.github/workflows/nuget.publish.nuget.org.yml@main
     with:
-        dotnet-version: 9.0.x
+      dotnet-version: 10.0.x
     secrets: inherit
-    
-    

--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -20,16 +20,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CSharpier.MSBuild" Version="1.1.2">
+    <PackageReference Include="CSharpier.MSBuild" Version="1.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.4" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="Scrutor" Version="6.1.0" />
     <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.9.0" />
   </ItemGroup>

--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Gainsway.Observability</RootNamespace>
     <PackageId>Gainsway.Observability</PackageId>
     <Version>0.0.0</Version>

--- a/src/Observability.csproj
+++ b/src/Observability.csproj
@@ -24,13 +24,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.4" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="Scrutor" Version="6.1.0" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
     <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/test/Observability.Tests.csproj
+++ b/test/Observability.Tests.csproj
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CSharpier.MSBuild" Version="1.1.2">
+    <PackageReference Include="CSharpier.MSBuild" Version="1.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -16,9 +16,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Observability.Tests.csproj
+++ b/test/Observability.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Gainsway.Observability.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->
This PR closes GAINS-1506

## Description

This pull request upgrades both the main project and test project to target .NET 10.0 and updates several package dependencies to their latest versions. The changes ensure compatibility with the newest .NET framework and improve stability and features by using the latest releases of key libraries.

Framework upgrade:

* Updated the `TargetFramework` in both `src/Observability.csproj` and `test/Observability.Tests.csproj` from `net9.0` to `net10.0`, ensuring the projects use the latest .NET runtime. [[1]](diffhunk://#diff-10c76ca212a40f0e87faedaabb729c22de0a1c187225113562f375df1d240d3eL3-R3) [[2]](diffhunk://#diff-7ce436fc3b9fedde557e14443d6eb7d16664b46757fc7e27f835873bf270501bL3-R21)

Dependency updates (main project):

* Upgraded all `OpenTelemetry` related packages (including `Exporter.OpenTelemetryProtocol`, `Extensions.Hosting`, `Instrumentation.AspNetCore`, `Instrumentation.AWS`, and `Instrumentation.Http`) from version `1.13.x` to `1.14.0` in `src/Observability.csproj` for improved observability features and bug fixes.
* Updated `CSharpier.MSBuild` from `1.1.2` to `1.2.1` to use the latest code formatting tools.

Dependency updates (test project):

* Upgraded `Microsoft.NET.Test.Sdk` from `18.0.0` to `18.0.1` and `NUnit.Analyzers` from `4.11.1` to `4.11.2` in `test/Observability.Tests.csproj` for improved testing features and analyzer accuracy.

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] New tests have been added to cover changes.
